### PR TITLE
tagのプッシュ方法が美しくないので修正

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,10 @@ jobs:
 
       - name: Create New Tag
         run: |
-          URL="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}"
+          git config user.name 'GitHub Actions'
+          git config user.email 'actions@github.com'
           git tag $TAG
-          git push $URL $TAG
+          git push --tags
 
       - name: Create New Release
         uses: actions/create-release@v1


### PR DESCRIPTION
Gitにユーザーの基本情報が設定されてないとupstreamにpushできない。 #7 作ったActionsではでタグをpushする際、ActorとTokenをURLに埋め込むことでこれを回避していたが、普通に `git config` する方が正攻法な気がするので修正